### PR TITLE
Added support for plugin dependencies

### DIFF
--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-with-dependencies/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-with-dependencies/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2008-2011 Don Brown
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.twdata.maven</groupId>
+    <artifactId>mojo-executor-test-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Mojo Executor - Test Project</name>
+    <description>
+        Used by the tests for the Mojo Executor Maven Plugin.
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.twdata.maven</groupId>
+                <artifactId>mojo-executor-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>execute-mojo</goal>
+                        </goals>
+                        <configuration>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-antrun-plugin</artifactId>
+                                <version>1.6</version>
+                            </plugin>
+                            <goal>run</goal>
+                            <configuration>
+                                <target>
+                                    <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                             classpathref="maven.plugin.classpath" />
+
+                                    <var name="pluginName" value="Mojo Executor"/>
+
+                                    <echo>${pluginName} ran successfully.</echo>
+                                </target>
+                            </configuration>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>ant-contrib</groupId>
+                                    <artifactId>ant-contrib</artifactId>
+                                    <version>1.0b3</version>
+                                    <exclusions>
+                                        <exclusion>
+                                            <groupId>ant</groupId>
+                                            <artifactId>ant</artifactId>
+                                        </exclusion>
+                                    </exclusions>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.ant</groupId>
+                                    <artifactId>ant-nodeps</artifactId>
+                                    <version>1.8.1</version>
+                                </dependency>
+                            </dependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-with-dependencies/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-with-dependencies/postbuild.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2008-2011 Don Brown
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+File buildLog = new File((String) basedir, "build.log")
+return buildLog.readLines().contains("     [echo] Mojo Executor ran successfully.");

--- a/mojo-executor-maven-plugin/src/main/java/org/twdata/maven/mojoexecutor/plugin/MojoExecutorMojo.java
+++ b/mojo-executor-maven-plugin/src/main/java/org/twdata/maven/mojoexecutor/plugin/MojoExecutorMojo.java
@@ -16,12 +16,15 @@
 package org.twdata.maven.mojoexecutor.plugin;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+
+import java.util.List;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
@@ -56,6 +59,14 @@ public class MojoExecutorMojo extends AbstractMojo {
      */
     private XmlPlexusConfiguration configuration;
 
+
+    /**
+     * Dependency configuration to use in the execution.
+     *
+     * @parameter
+     */
+    private List<Dependency> dependencies;
+
     /**
      * The project currently being build.
      *
@@ -83,7 +94,7 @@ public class MojoExecutorMojo extends AbstractMojo {
     private BuildPluginManager pluginManager;
 
     public void execute() throws MojoExecutionException {
-        executeMojo(plugin, goal, toXpp3Dom(configuration),
+        executeMojo(plugin, goal, toXpp3Dom(configuration), dependencies,
                 executionEnvironment(mavenProject, mavenSession, pluginManager));
     }
 }

--- a/mojo-executor/src/main/java/org/twdata/maven/mojoexecutor/MojoExecutor.java
+++ b/mojo-executor/src/main/java/org/twdata/maven/mojoexecutor/MojoExecutor.java
@@ -16,6 +16,7 @@
 package org.twdata.maven.mojoexecutor;
 
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecution;
@@ -25,6 +26,10 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.twdata.maven.mojoexecutor.PlexusConfigurationUtils.toXpp3Dom;
 
@@ -64,6 +69,14 @@ public class MojoExecutor {
      */
     public static void executeMojo(Plugin plugin, String goal, Xpp3Dom configuration, ExecutionEnvironment env)
             throws MojoExecutionException {
+
+        executeMojo(plugin, goal, configuration, Collections.<Dependency>emptyList(), env);
+    }
+
+    public static void executeMojo(Plugin plugin, String goal, Xpp3Dom configuration, List<Dependency> dependencies,
+                                   ExecutionEnvironment env) throws MojoExecutionException {
+
+
         if (configuration == null) {
             throw new NullPointerException("configuration may not be null");
         }
@@ -73,6 +86,12 @@ public class MojoExecutor {
                 int pos = goal.indexOf('#');
                 executionId = goal.substring(pos + 1);
                 goal = goal.substring(0, pos);
+            }
+
+            if (dependencies != null) {
+                for (Dependency dependency : dependencies) {
+                    plugin.addDependency(dependency);
+                }
             }
 
             MavenSession session = env.getMavenSession();
@@ -161,6 +180,32 @@ public class MojoExecutor {
         plugin.setGroupId(groupId);
         plugin.setVersion(version);
         return plugin;
+    }
+
+    /**
+     * Defines a dependency
+     *
+     * @param groupId    The group id
+     * @param artifactId The artifact id
+     * @param version    The plugin version
+     * @return the dependency instance
+     */
+    public static Dependency dependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        return dependency;
+    }
+
+    /**
+     * Creates a list of dependencies.
+     *
+     * @param dependencies the dependencies
+     * @return A list of dependencies
+     */
+    public static List<Dependency> dependencies(Dependency... dependencies) {
+        return Arrays.asList(dependencies);
     }
 
     /**


### PR DESCRIPTION
I added support for plugin dependencies.  I would appreciate it if you could take a look at it and see if this is something that you want to add to the mainline

Here's an example of what it looks like when you use it : 

```
    executeMojo(
            plugin(
                    groupId("org.apache.maven.plugins"),
                    artifactId("maven-assembly-plugin"),
                    version("2.3")
            ),
            goal("single"),
            configuration(
                    element(name("appendAssemblyId"), "false"),
                    element(name("finalName"), project.getArtifactId()),
                    element(name("descriptorRefs"),
                            element(name("descriptorRef"), "puppet-module"))
            ),
            dependencies(
                    dependency(
                            groupId("com.company.descriptors"),
                            artifactId("my-descriptor"),
                            version("0.1.0-SNAPSHOT")
                    )
            ),
            executionEnvironment(
                    project,
                    session,
                    pluginManager
            )
    );
```

I extended the dsl and made sure that it does not break backwards compatibility. All tests pass and i added one extra test that illustrates the feature
