### PR TITLE
Updated dependencies to fix security vulnerabilities

### DIFF
--- a/mojo-executor-maven-plugin/pom.xml
+++ b/mojo-executor-maven-plugin/pom.xml
@@ -43,10 +43,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -72,6 +74,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-blocking/postbuild.groovy
@@ -20,6 +20,6 @@ def v1 = text.contains("[INFO] Executing 'org.apache.maven.plugins:maven-depende
 def v2 = text.contains("""[INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime""");
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:provided
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.36:runtime""");
 return v1 && v2;

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-no-plugin-version/postbuild.groovy
@@ -20,6 +20,6 @@ return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:provided
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.36:runtime
 """);

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-null-maven-project/postbuild.groovy
@@ -20,6 +20,6 @@ return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:provided
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.36:runtime
 """);

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project-quiet/postbuild.groovy
@@ -20,6 +20,6 @@ return ! text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:provided
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.36:runtime
 """);

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/pom.xml
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
+++ b/mojo-executor-maven-plugin/src/it/mojo-executor-test-project/postbuild.groovy
@@ -20,6 +20,6 @@ return text.contains("""
 [INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.11:test
 [INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
-[INFO]    org.slf4j:slf4j-api:jar:1.7.4:provided
-[INFO]    org.slf4j:slf4j-nop:jar:1.7.4:runtime
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:provided
+[INFO]    org.slf4j:slf4j-nop:jar:1.7.36:runtime
 """);

--- a/mojo-executor/src/test/java/org/twdata/maven/mojoexecutor/MojoExecutorTest.java
+++ b/mojo-executor/src/test/java/org/twdata/maven/mojoexecutor/MojoExecutorTest.java
@@ -25,7 +25,6 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.repository.RemoteRepository;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -33,20 +32,22 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.AdditionalMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.attribute;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.attributes;
@@ -92,7 +93,7 @@ public class MojoExecutorTest {
                                 dependency("org.apache.maven.plugins", "some-plugin", "1.0")
                         )
                 )),
-                anyListOf(RemoteRepository.class),
+            AdditionalMatchers.or(anyList(), isNull()),
                 same(repositorySession)
         )).thenReturn(mavenDependencyPluginDescriptor);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.8.1</maven.version>
+    <maven.version>3.5.0</maven.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.5.0</maven.version>
+    <maven.version>3.8.1</maven.version>
   </properties>
 
   <dependencyManagement>
@@ -133,17 +133,17 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.4</version>
+        <version>3.6.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-embedder</artifactId>
-        <version>3.3.1</version>
+        <version>3.8.4</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.1</version>
       </dependency>
 
       <dependency>
@@ -160,13 +160,13 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
-        <version>1.3</version>
+        <version>2.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.8.5</version>
+        <version>4.3.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -177,12 +177,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>1.7.36</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.30</version>
+        <version>1.7.36</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -193,7 +193,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.9.0</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -202,12 +202,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -217,7 +217,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.1</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>
@@ -238,7 +238,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.4</version>
+          <version>0.8.7</version>
           <executions>
             <execution>
               <goals>
@@ -259,7 +259,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-dependencies</id>
@@ -319,7 +319,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
sonatype-lift flagged version 2.3.2 with the following security vulnerabilities:

*Critical OSS Vulnerability:*
### pkg:maven/org.twdata.maven/mojo-executor@2.3.2
28 Critical, 1 Severe, 0 Moderate, 56 Unknown vulnerabilities have been found across 29 dependencies

<details>
  <summary><b>Components</b></summary><br/>
  <ul>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/commons-io/commons-io@2.6</b></summary>
        <ul>
  <details>
    <summary><b>SEVERE Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2021-29425] In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normaliz...
> In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like &quot;//../foo&quot;, or &quot;\\..\foo&quot;, the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus &quot;limited&quot; path traversal), if the calling code would use the result to construct a path value.
>
> **CVSS Score:** 5.3
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N

</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
      <details>
        <summary><b>pkg:maven/org.codehaus.plexus/plexus-utils@2.1</b></summary>
        <ul>
  <details>
    <summary><b>CRITICAL Vulnerabilities (1)</b></summary><br/>
<ul>

> #### [CVE-2017-1000487]  Improper Neutralization of Special Elements used in a Command (Command Injection)
> Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.
>
> **CVSS Score:** 9.8
>
> **CVSS Vector:** CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

</ul>
    </details>
  <details>
    <summary><b>UNKNOWN Vulnerabilities (2)</b></summary><br/>
<ul>
<details>
            <summary>OSSINDEX-d093-0e6b-3210</summary>

> #### Possible XML Injection
> &gt; `org.codehaus.plexus.util.xml.XmlWriterUtil#writeComment(XMLWriter, String, int, int, int)` does not check if the comment includes a `&quot;--&gt;&quot;` sequence.  This means that text contained in the command string could be interpreted as XML, possibly leading to XML injection issues, depending on how this method is being called.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/3)
>
> **CVSS Score:** 0

</details>
<details>
            <summary>OSSINDEX-d89d-15b4-33be</summary>

> #### Directory traversal in org.codehaus.plexus.util.Expand
> &gt; org.codehaus.plexus.util.Expand does not guard against directory traversal, but such protection is generally expected from unarchiving tools.&gt; &gt; -- [github.com](https://github.com/codehaus-plexus/plexus-utils/issues/4)
>
> **CVSS Score:** 0

</details>
</ul>
    </details>
        </ul>
      </details>
  </ul>
</details>
(at-me [in a reply](https://help.sonatype.com/lift/talking-to-lift) with `help` or `ignore`)