### PR TITLE
Dropped support for Maven 3.2.5 to avoid security vulnerabilities in …

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        maven: [3.2.5, 3.5.4, 3.6.3, 3.8.1]
+        maven: [3.5.4, 3.6.3, 3.8.1]
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
     if: github.repository == 'mojo-executor/mojo-executor' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.5.0</maven.version>
+    <maven.version>3.8.4</maven.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
…outdated versions of plexus-utils, commons-io.