### PR TITLE
Skip GitHub Action deployments on release builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,6 +72,6 @@ jobs:
                 "password": "${{ secrets.SONATYPE_PASSWORD }}"
             }]
     - name: Deploy Snapshot
-      run: mvn -B -V org.apache.maven.plugins:maven-source-plugin:jar-no-fork deploy
+      run: mvn -B -V -Dmaven.deploy.skip=releases org.apache.maven.plugins:maven-source-plugin:jar-no-fork deploy
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.0.0-M2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Uses the new syntax for the `skip` parameter in maven-deploy-plugin
version 3.0.0-M2.

https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#skip

Fixes #68.