### PR TITLE
Update GitHub Actions to latest Maven patch releases

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,16 +5,16 @@ name: CI
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        maven: [3.3.1, 3.5.4, 3.6.3, 3.8.7, 3.9.0, 4.0.0-alpha-4]
+        maven: [3.3.1, 3.5.4, 3.6.3, 3.8.8, 3.9.6, 4.0.0-alpha-12]
         jdk: ["11"]
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
     if: github.repository == 'mojo-executor/mojo-executor' && github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 .classpath
 .project
 .settings
+.mvn/wrapper/
+mvnw*

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,26 @@
           <version>2.5.3</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+        </plugin>
+        <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.7</version>


### PR DESCRIPTION
Other changes:

- Fix syntax of GitHub Actions workflow configuration
- Ignore generated Maven Wrapper files
- Set versions of more Maven plugins to silence warnings in Maven 4 alphas