### PR TITLE
Update testing matrix to include Maven 4.0.0-alpha-13

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,8 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        maven: [3.3.1, 3.5.4, 3.6.3, 3.8.8, 3.9.6, 4.0.0-alpha-12]
-        jdk: ["11"]
+        maven: [3.3.1, 3.5.4, 3.6.3, 3.8.8, 3.9.6, 4.0.0-alpha-13]
+        jdk: [11, 17]
+        exclude:
+          - maven: 4.0.0-alpha-13
+            jdk: 11
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
     if: github.repository == 'mojo-executor/mojo-executor' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -43,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: ${{ matrix.jdk }}
         distribution: "temurin"
         cache: 'maven'        
     # https://github.com/marketplace/actions/maven-settings-action


### PR DESCRIPTION
This version now requires Java 17, so that was added to the testing matrix alongside Java 11.