### PR TITLE
Update to the latest Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -237,12 +237,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -277,7 +277,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.11</version>
+          <version>0.8.12</version>
           <executions>
             <execution>
               <goals>
@@ -314,7 +314,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0,4.0)</version>
+                  <version>[3.3.1,4.0)</version>
                   <message>Version 2.x of Mojo Executor requires Maven ${maven.version}. Use Mojo Executor 1.x with Maven 2.</message>
                 </requireMavenVersion>
               </rules>


### PR DESCRIPTION
Also update the minimum enforced Maven version for the project build to 3.3.1. This was already the minimum version supported at runtime, and the minimum version actually used to build in GitHub actions.

The maven-compiler-plugin has a new version that was not included in this update (3.13.0), because it requires Maven 3.6.3 or later.