### PR TITLE
Disable snapshot deployment on Dependabot pushes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
       uses: codecov/codecov-action@v4
 
   snapshot:
-    if: github.repository == 'mojo-executor/mojo-executor' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository == 'mojo-executor/mojo-executor' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions triggered by Dependabot do not have access to repository secrets, so skip snapshot deployment on these changes.

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

This explains some of the recent build failures on `main` (but not the ones that @olamy merged directly).

We won't know if this fixes the problem until after the pull request is merged, but I wanted to open it for discussion rather than pushing directly to `main`. There are other possible solutions, such as using Dependabot secrets, but this seemed safer, and I'm not sure that it's really important to deploy a snapshot on every dependency change.