### PR TITLE
 mojo executor throwing exception when executionId is passed

### DIFF
--- a/mojo-executor/src/main/java/org/twdata/maven/mojoexecutor/MojoExecutor.java
+++ b/mojo-executor/src/main/java/org/twdata/maven/mojoexecutor/MojoExecutor.java
@@ -125,10 +125,12 @@ public class MojoExecutor {
 
     private static MojoExecution mojoExecution(MojoDescriptor mojoDescriptor, String executionId,
                                                Xpp3Dom configuration) {
+        configuration = Xpp3DomUtils.mergeXpp3Dom(configuration, toXpp3Dom(mojoDescriptor.getMojoConfiguration()));
         if (executionId != null) {
-            return new MojoExecution(mojoDescriptor, executionId);
+            MojoExecution mojoExecution = new MojoExecution(mojoDescriptor, executionId);
+            mojoExecution.setConfiguration(configuration);
+            return mojoExecution;
         } else {
-            configuration = Xpp3DomUtils.mergeXpp3Dom(configuration, toXpp3Dom(mojoDescriptor.getMojoConfiguration()));
             return new MojoExecution(mojoDescriptor, configuration);
         }
     }

--- a/mojo-executor/src/test/java/org/twdata/maven/mojoexecutor/MojoExecutorTest.java
+++ b/mojo-executor/src/test/java/org/twdata/maven/mojoexecutor/MojoExecutorTest.java
@@ -288,10 +288,14 @@ public class MojoExecutorTest {
                         pluginManager
                 )
         );
+        MojoExecution mojoExecution = new MojoExecution(copyDependenciesMojoDescriptor, "execution");
+        mojoExecution.setConfiguration(configuration(
+                element(name("outputDirectory"), "${project.build.directory}/foo")
+        ));
         verify(pluginManager)
                 .executeMojo(
                         same(session),
-                        argThat(is(equalTo(new MojoExecution(copyDependenciesMojoDescriptor, "execution"))))
+                        argThat(is(equalTo(mojoExecution)))
                 );
     }
 


### PR DESCRIPTION
When using executionId in executeMojo method,
example :- executeMojo(plugin, goal("compile#default-compile"), config, executionEnvironment(tempProject, tempSession, pluginManager)); 

executeMojo is throwing below exception

Unable to execute mojo: The parameters 'basedir', 'mojoExecution', 'compilePath', 'compileSourceRoots', 'session', 'project', 'outputDirectory', 'projectArtifact', 'buildDirectory' for goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile are missing or invalid -> [Help 1]


logic change needed to create MojoExecution() object with executionId and configuration set into object